### PR TITLE
Dont' add "Transfer-Encoding:chunked" if no body

### DIFF
--- a/reactor-net/src/main/java/reactor/io/net/http/BaseHttpChannel.java
+++ b/reactor-net/src/main/java/reactor/io/net/http/BaseHttpChannel.java
@@ -274,6 +274,7 @@ public abstract class BaseHttpChannel<IN, OUT> extends Flux<IN> implements Intro
 		@Override
 		public void subscribe(final Subscriber<? super Void> s) {
 			if(markHeadersAsFlushed()){
+				headers().transferEncodingChunked();
 				doSubscribeHeaders(new PostHeaderWriteSubscriber(s));
 			}
 			else{

--- a/reactor-net/src/main/java/reactor/io/net/impl/netty/http/NettyHttpClientHandler.java
+++ b/reactor-net/src/main/java/reactor/io/net/impl/netty/http/NettyHttpClientHandler.java
@@ -73,7 +73,6 @@ public class NettyHttpClientHandler extends NettyChannelHandlerBridge {
 		if(httpChannel == null) {
 			httpChannel = new PostHeaderPublisher();
 			httpChannel.keepAlive(true);
-			httpChannel.headers().transferEncodingChunked();
 		}
 
 


### PR DESCRIPTION
This commit makes sure that the "Transfer-Encoding: chunked" client HTTP
request header is not added for requests that have no request body.
Indeed, "Content-Length" and "Transfer-Encoding: chunked" headers should
only be added for messages that have a body.

Instead of being added at the "client channel active" level for all
requests, this header value is added the first time
`request.writeWith(Publisher pub)` is called, thus flushing the requests
headers before writing the actual body.