### PR TITLE
Add missing NettyHttpHeaders impl

### DIFF
--- a/reactor-net/src/main/java/reactor/io/net/impl/netty/http/NettyHttpHeaders.java
+++ b/reactor-net/src/main/java/reactor/io/net/impl/netty/http/NettyHttpHeaders.java
@@ -75,6 +75,7 @@ public class NettyHttpHeaders implements HttpHeaders {
 
 	@Override
 	public HttpHeaders removeTransferEncodingChunked() {
+		io.netty.handler.codec.http.HttpHeaders.removeTransferEncodingChunked(nettyRequest);
 		return this;
 	}
 
@@ -92,6 +93,7 @@ public class NettyHttpHeaders implements HttpHeaders {
 
 	@Override
 	public HttpHeaders contentLength(long length) {
+		io.netty.handler.codec.http.HttpHeaders.setContentLength(nettyRequest, length);
 		return this;
 	}
 


### PR DESCRIPTION
This commit adds the missing implementation for
`remoteTransferEncodingChunked` and `setContentLength` which are no-op
at the moment.